### PR TITLE
Class yii\base\Object is depercated

### DIFF
--- a/src/CasService.php
+++ b/src/CasService.php
@@ -15,7 +15,7 @@ use yii\helpers\Url;
  *
  * @author François Gannaz <francois.gannaz@poofe.info>
  */
-class CasService extends \yii\base\Object
+class CasService extends \yii\base\BaseObject
 {
     const LOGPATH = '@runtime/logs/cas.log';
 


### PR DESCRIPTION
class yii\base\Object has been replaced by \yii\base\BaseObject in version 2.0.13 because `object` has become a reserved word which can not be used as class name in PHP 7.2.